### PR TITLE
Bump scheule delay to avoid reconnecting too often

### DIFF
--- a/schedule.js
+++ b/schedule.js
@@ -232,7 +232,7 @@ function (gossip, config, server) {
         }
       })
 
-    }, 100*Math.random())
+    }, 1000*Math.random())
     if(timer.unref) timer.unref()
   }
 


### PR DESCRIPTION
When using ssb-friend-pub you only get a very small number of peers to connect to. In this setting it is much more likely that you don't have "enough" peers, meaning that ssb-gossip will try as fast as it can to reconnect to the same peers over and over. Before the delay was between 10 and 100ms, which seems really low. With this patch the delay is bumped to 100ms to 1000ms instead which I think it more reasonable.