### PR TITLE
softer upper limit on quota

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ module.exports = {
 
       },
 
-      disconnect: valid.async(function (addr, cb) {
+      disconnect: function (addr, cb) {
         var peer = gossip.get(addr)
 
         peer.state = 'disconnecting'
@@ -221,7 +221,7 @@ module.exports = {
           cb && cb()
         })
 
-      }, 'string|object'),
+      },
 
       changes: function () {
         return notify.listen()
@@ -230,6 +230,7 @@ module.exports = {
       add: valid.sync(function (addr, source) {
 
         if(isObject(addr)) {
+          //console.log(addr)
           addr.address = coearseAddress(addr)
         }
         else {
@@ -413,6 +414,4 @@ module.exports = {
     return gossip
   }
 }
-
-
 

--- a/schedule.js
+++ b/schedule.js
@@ -122,7 +122,7 @@ function (gossip, config, server) {
     var connected = peers.filter(isConnect).filter(filter)
 
     //disconnect if over quota
-    if(connected.length > opts.quota) {
+    if(connected.length > opts.quota * 2) {
       return earliest(connected, connected.length - opts.quota)
         .forEach(function (peer) {
           gossip.disconnect(peer, function () {})


### PR DESCRIPTION
currently, ssb-gossip tries to maintain exactly `quota` connections. if it's under, it creates more, if it's over it disconnects some.

things like ssb-tunnel require their own connections, but they keep on getting disconnected by gossip scheduler.

so, be less up tight about keeping exactly to the quota. create more connections when under the quota, but don't start killing connections until you are double the quota.