### PR TITLE
gracefully handle ping callback with no error

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,7 +342,7 @@ module.exports = {
         pull(
           pp,
           rpc.gossip.ping({timeout: timer_ping}, function (err) {
-            if(err.name === 'TypeError') peer.ping.fail = true
+            if(err && err.name === 'TypeError') peer.ping.fail = true
           }),
           pp
         )


### PR DESCRIPTION
fixes error

``` 
TypeError: Cannot read property 'name' of null
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/ssb-gossip/index.js:345:20
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/muxrpc/pull-weird.js:18:14
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/muxrpc/pull-weird.js:10:5
    at PacketStreamSubstream.weird.read (/home/dinosaur/repos/ssbc/patchwork/node_modules/muxrpc/pull-weird.js:37:15)
    at PacketStream._onstream (/home/dinosaur/repos/ssbc/patchwork/node_modules/packet-stream/index.js:200:12)
    at PacketStream.write (/home/dinosaur/repos/ssbc/patchwork/node_modules/packet-stream/index.js:135:41)
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/muxrpc/pull-weird.js:56:15
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/pull-stream/sinks/drain.js:24:37
    at /home/dinosaur/repos/ssbc/patchwork/node_modules/pull-goodbye/node_modules/pull-stream/throughs/filter.js:17:11
    at Object.cb (/home/dinosaur/repos/ssbc/patchwork/node_modules/packet-stream-codec/index.js:111:11)
```